### PR TITLE
Cmlee

### DIFF
--- a/src/main/java/com/ll/framework/ioc/ApplicationContext.java
+++ b/src/main/java/com/ll/framework/ioc/ApplicationContext.java
@@ -1,11 +1,22 @@
 package com.ll.framework.ioc;
 
+import com.ll.domain.testPost.testPost.repository.TestPostRepository;
+import com.ll.domain.testPost.testPost.service.TestPostService;
+
+import java.util.HashMap;
+import java.util.Map;
+
 public class ApplicationContext {
     public ApplicationContext() {
 
     }
+    private Map<String,Object> bens = new HashMap<>();
 
     public <T> T genBean(String beanName) {
+       if(beanName.equals("testPostService")){
+           TestPostRepository testPostRepository = new TestPostRepository();
+           return (T) new TestPostService(testPostRepository);
+       }
         return (T) null;
     }
 }

--- a/src/main/java/com/ll/framework/ioc/ApplicationContext.java
+++ b/src/main/java/com/ll/framework/ioc/ApplicationContext.java
@@ -1,6 +1,7 @@
 package com.ll.framework.ioc;
 
 import com.ll.domain.testPost.testPost.repository.TestPostRepository;
+import com.ll.domain.testPost.testPost.service.TestFacadePostService;
 import com.ll.domain.testPost.testPost.service.TestPostService;
 
 import java.util.HashMap;
@@ -31,6 +32,18 @@ public class ApplicationContext {
             TestPostRepository testPostRepository = new TestPostRepository();
             beans.put(beanName, testPostRepository);
             return (T) testPostRepository;
+        }
+
+        if(beanName.equals("testFacadePostService")){
+            // t6: 파사드 서비스도 필요한 빈들을 컨테이너에서 받아 조립한다.
+            TestPostService testPostService = genBean("testPostService");
+            TestPostRepository testPostRepository = genBean("testPostRepository");
+            TestFacadePostService testFacadePostService = new TestFacadePostService(
+                    testPostService,
+                    testPostRepository
+            );
+            beans.put(beanName, testFacadePostService);
+            return (T) testFacadePostService;
         }
 
         return (T) null;

--- a/src/main/java/com/ll/framework/ioc/ApplicationContext.java
+++ b/src/main/java/com/ll/framework/ioc/ApplicationContext.java
@@ -10,13 +10,20 @@ public class ApplicationContext {
     public ApplicationContext() {
 
     }
-    private Map<String,Object> bens = new HashMap<>();
+    private Map<String,Object> beans = new HashMap<>();
 
     public <T> T genBean(String beanName) {
-       if(beanName.equals("testPostService")){
-           TestPostRepository testPostRepository = new TestPostRepository();
-           return (T) new TestPostService(testPostRepository);
-       }
+        if (beans.containsKey(beanName)) {
+            // t3: IoC 컨테이너가 이미 만든 빈을 보관했다가 같은 객체를 다시 돌려준다.
+            return (T) beans.get(beanName);
+        }
+
+        if(beanName.equals("testPostService")){
+            TestPostRepository testPostRepository = new TestPostRepository();
+            TestPostService testPostService = new TestPostService(testPostRepository);
+            beans.put(beanName, testPostService);
+            return (T) testPostService;
+        }
         return (T) null;
     }
 }

--- a/src/main/java/com/ll/framework/ioc/ApplicationContext.java
+++ b/src/main/java/com/ll/framework/ioc/ApplicationContext.java
@@ -24,6 +24,14 @@ public class ApplicationContext {
             beans.put(beanName, testPostService);
             return (T) testPostService;
         }
+
+        if(beanName.equals("testPostRepository")){
+            // t4: 저장소도 컨테이너가 이름으로 찾아 만들 수 있는 빈으로 등록한다.
+            TestPostRepository testPostRepository = new TestPostRepository();
+            beans.put(beanName, testPostRepository);
+            return (T) testPostRepository;
+        }
+
         return (T) null;
     }
 }

--- a/src/main/java/com/ll/framework/ioc/ApplicationContext.java
+++ b/src/main/java/com/ll/framework/ioc/ApplicationContext.java
@@ -19,7 +19,8 @@ public class ApplicationContext {
         }
 
         if(beanName.equals("testPostService")){
-            TestPostRepository testPostRepository = new TestPostRepository();
+            // t5: 서비스가 의존 객체를 직접 만들지 않고 컨테이너에서 받아 DI 되도록 한다.
+            TestPostRepository testPostRepository = genBean("testPostRepository");
             TestPostService testPostService = new TestPostService(testPostRepository);
             beans.put(beanName, testPostService);
             return (T) testPostService;


### PR DESCRIPTION
## 작업 내용

Spring IoC 학습 테스트를 단계별로 통과시키기 위해 `ApplicationContext`에 빈 생성, 저장, 의존성 주입 로직을 추가했습니다.

## 단계별 진행

### t3 green

`testPostService` 빈을 다시 요청했을 때 같은 객체가 반환되도록 `Map<String, Object>` 기반 빈 저장소를 추가했습니다.

이를 통해 IoC 컨테이너가 객체를 직접 관리하고, 같은 빈 이름에 대해 싱글톤처럼 동일 인스턴스를 반환하는 흐름을 구현했습니다.

### t4 green

`testPostRepository` 빈을 이름으로 요청할 수 있도록 생성 로직을 추가했습니다.

서비스뿐 아니라 저장소 객체도 컨테이너가 직접 생성하고 관리하는 빈으로 등록했습니다.

### t5 green

`TestPostService` 생성 시 `TestPostRepository`를 직접 `new`로 만들지 않고, `ApplicationContext`의 `genBean("testPostRepository")`를 통해 받아오도록 변경했습니다.

이를 통해 서비스가 의존 객체 생성 책임을 가지지 않고, 컨테이너가 의존성을 주입하는 DI 흐름을 반영했습니다.

### t6 green

`testFacadePostService` 빈 생성 로직을 추가했습니다.

`TestFacadePostService`가 필요로 하는 `TestPostService`, `TestPostRepository`를 모두 컨테이너에서 가져와 생성자에 주입하도록 구현했습니다.

## 학습 포인트

- IoC 컨테이너가 객체 생성 책임을 가진다.
- 생성된 빈을 컨테이너에 저장해 같은 이름 요청 시 같은 객체를 반환한다.
- 객체가 직접 의존 객체를 만들지 않고, 컨테이너가 의존성을 조립해준다.
- 여러 빈 간의 의존 관계도 컨테이너를 통해 연결할 수 있다.